### PR TITLE
Add: 認証状態をローカルストレージに保存されるように変更

### DIFF
--- a/src/firebase/firebase.js
+++ b/src/firebase/firebase.js
@@ -1,4 +1,5 @@
 import { initializeApp } from "firebase/app"
+import { getAuth, setPersistence, browserLocalPersistence } from "firebase/auth"
 
 const config = {
   apiKey: process.env.VUE_APP_API_KEY,
@@ -11,5 +12,9 @@ const config = {
 }
 
 const app = initializeApp(config)
+
+const auth = getAuth()
+
+setPersistence(auth, browserLocalPersistence)
 
 export default app

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -39,6 +39,7 @@ const router = new VueRouter({
 
 router.beforeEach((to, from, next) => {
   const isAuthenticated = store.getters['auth/isAuthenticated']
+  console.log(isAuthenticated)
   if(to.name !== 'Login' && !isAuthenticated) next({name: 'Login'})
   else next()
 })

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -21,8 +21,9 @@ export default new Vuex.Store({
   plugins: [createPersistedState({
     key: 'sharefor',
     paths: [
-      'loading.isLoading'
+      'loading.isLoading',
+      'auth.isAuthenticated'
     ],
-    storage: window.sessionStorage
+    // storage: window.sessionStorage
   })]
 })

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -106,12 +106,7 @@
         const auth = getAuth()
         signOut(auth).then(() => {
           this.isSignOut()
-          this.signOutMessage = 'ログアウトしました'
-          if(this.signOutMessage !== undefined){
-            setTimeout(() => {
-              this.signOutMessage = undefined
-            }, 3000)
-          }
+          this.$router.push({name: 'Login', params: {message: 'ログアウトしました'}})
         }).catch(() => {
           this.signOutErrorMessage = 'ログアウトに失敗しました'
           this.closeMessageThreeSecondsLater(this.signOutErrorMessage)

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -10,6 +10,16 @@
       {{errorMessage}}
     </v-alert>
 
+    <v-alert
+      :value="signOutMessage !== undefined"
+      type="success"
+      dense
+      class="mt-0 text-center"
+      transition="slide-y-transition"
+    >
+      {{signOutMessage}}
+    </v-alert>
+
     <v-progress-circular
     v-if="isLoading"
       indeterminate
@@ -74,12 +84,16 @@ import { mapActions, mapGetters } from 'vuex'
 
 export default {
   name: 'Login',
+  props: ['message'],
   data() {
     return {
       errorMessage: undefined,
+      signOutMessage: undefined
     }
   },
   created() {
+    this.setSignOutMessage()
+    this.signInRedirect()
     setTimeout(() => {
       this.stopLoading()
     },  6000)
@@ -89,7 +103,7 @@ export default {
     this.getSignInResult()
   },
   methods: {
-    ...mapActions('auth', ['setResult']),
+    ...mapActions('auth', ['setResult', 'onAuth']),
     ...mapActions('loading', ['loading', 'stopLoading']),
     signInTwitter() {
         this.loading()
@@ -127,9 +141,23 @@ export default {
         this.errorMessage = 'ログインに失敗しました'
         this.closeMessageThreeSecondsLater()
     },
+    setSignOutMessage() {
+      this.signOutMessage = this.message
+      if(this.signOutMessage !== undefined){
+        setTimeout(() => {
+          this.signOutMessage = undefined
+        }, 3000)
+      }
+    },
+    signInRedirect() {
+      if(this.isAuthenticated) {
+        this.$router.push({name: 'Home'})
+      }
+    }
   },
   computed: {
-    ...mapGetters('loading', ['isLoading'])
+    ...mapGetters('loading', ['isLoading']),
+    ...mapGetters('auth', ['isAuthenticated'])
   }
 }
 </script>


### PR DESCRIPTION
firebaseの認証情報を取得する前にナビゲーションガードが発火する。
そのためリロードすると常に未認証の状態になるためローカルストレージに保存されるように変更した。