### PR TITLE
Add: firestoreのDB構成を変更

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -39,7 +39,6 @@ const router = new VueRouter({
 
 router.beforeEach((to, from, next) => {
   const isAuthenticated = store.getters['auth/isAuthenticated']
-  console.log(isAuthenticated)
   if(to.name !== 'Login' && !isAuthenticated) next({name: 'Login'})
   else next()
 })

--- a/src/store/modules/posts.js
+++ b/src/store/modules/posts.js
@@ -1,12 +1,13 @@
 import { format } from 'date-fns'
 import app from '../../firebase/firebase'
-import { getFirestore, collection, getDocs, query, orderBy } from 'firebase/firestore'
+import { getFirestore, getDocs, query, orderBy, collectionGroup } from 'firebase/firestore'
 
 const db = getFirestore(app)
 
 const state = {
   posts: [],
-  tags: []
+  tags: [],
+  eachUserPosts: []
 }
 const getters = {
   posts: state => state.posts,
@@ -20,8 +21,9 @@ const mutations = {
 }
 const actions = {
   async getPosts({ commit }) {
-    const postsRef = collection(db, 'posts')
-    const q = query(postsRef, orderBy('created_at', 'desc'))
+    const postsCollectionGroup = collectionGroup(db, 'posts')
+    // const usersCollectionRef = collection(db, 'users', 'posts')
+    const q = query(postsCollectionGroup, orderBy('created_at', 'desc'))
     const querySnapshot = await getDocs(q)
     let postList = querySnapshot.docs.map(doc => doc.data())
     let tags = []

--- a/src/views/Form.vue
+++ b/src/views/Form.vue
@@ -1,5 +1,15 @@
 <template>
   <div>
+    <v-alert
+      :value="postErrorMessage !== undefined"
+      type="error"
+      dense
+      class="mt-0 text-center"
+      transition="slide-y-transition"
+    >
+      {{postErrorMessage}}
+    </v-alert>
+    
     <v-row justify="center">
       <v-dialog
         v-model="dialog"
@@ -47,6 +57,7 @@
           <post-form
             @recieve-close="checkClicked"
             @recieve-send="checkClicked"
+            @post-error="setMessage"
           />
         </v-card>
 
@@ -73,6 +84,7 @@ export default {
       dialog: false,
       postButtonClicked: false,
       recruitmentButtonClicked: false,
+      postErrorMessage: undefined,
       recruitmentForm: {
         stadiums: jLeagueTeamList,
         text2: '',
@@ -89,6 +101,10 @@ export default {
         this.recruitmentButtonClicked = false
       }, 300)
     },
+    setMessage(message) {
+      console.log(message)
+      this.postErrorMessage = message
+    }
   },
   components: {
     PostForm,

--- a/src/views/PostList.vue
+++ b/src/views/PostList.vue
@@ -2,7 +2,7 @@
   <div>
     <v-container>
       <v-row class="d-sm-flex flex-sm-wrap">
-        <v-col cols="12" sm="6" lg="4" v-for="(post, index) in posts" :key="index">
+        <v-col cols="12" sm="6" lg="4" v-for="post in posts" :key="post.post_id">
           <v-card
             class="mx-auto rounded-0"
             max-width="344"
@@ -95,6 +95,7 @@ export default {
   },
   computed: {
     ...mapGetters('posts', ['posts']),
+    ...mapGetters('auth', ['user'])
   }
 }
 </script>


### PR DESCRIPTION
認証機能を作成してユーザー毎に投稿を保存する必要が出てきたため、
usersコレクション/uid/postsコレクション/ 以下に投稿を保存するように変更した。